### PR TITLE
support local files

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
 		"tabs",
 		"http://*/*", 
 		"https://*/*", 
-    "file://*/*", 
+		"file://*/*", 
 		"contextMenus"
 	] 
 }

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
 	"permissions": [
 		"tabs",
 		"http://*/*", 
-		"https://*/*",
+		"https://*/*", 
+    "file://*/*", 
 		"contextMenus"
 	] 
 }


### PR DESCRIPTION
When developing css locally from an html file, the extension currently does not activate. There are no errors or warning, just silence. This one line fix allows support for html files opening from the filesystem.
