### PR TITLE
Aseged woldeselassie

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Known Issues
 Changelog
 ---------
 
+*  1.8 - 02/2018 - Fixed overlapping text issue on the header. In 'CSSViewer_block h1' increased line-height to 10px, changed 'padding:30px 10px 5px 10px', and changed width:322px.
 *  1.7 - 04/2017 - Add keyboard shortcuts and enable the viewer for local files.
 *  1.6 - 11/2014 - Add inspect element to menu. Add generate css definition. Fix few issues with auto-positioning. reFix an issue with chrome/38.
 *  1.5 - 10/2015 - Hotfix an issue with Chrome/38.0.2125.101.

--- a/css/cssviewer.css
+++ b/css/cssviewer.css
@@ -53,13 +53,12 @@ span.CSSViewer_property,
 	font-size:12px !important;
 	text-transform:none !important;
 	text-align:center !important;
-	width:332px !important;
+	width:322px !important;
 	display:block !important; 
 	background:url("chrome-extension://__MSG_@@extension_id__/img/header.png") !important;
-	padding:30px 0 10px 0 !important;
+	padding:30px 10px 5px 10px !important;
 	margin:5% auto;
-	overflow:hidden !important;
-	line-height: 5px;
+	line-height: 10px;
 }
 
 #CSSViewer_center


### PR DESCRIPTION
Made few changes to the cssviewer.css fix overlapping text in the header. 
Before;
![image](https://user-images.githubusercontent.com/15934887/36505074-532e964c-174a-11e8-8f32-16fbd462ed8f.png)


After;
![image](https://user-images.githubusercontent.com/15934887/36504999-269bbf7e-174a-11e8-8e5c-f082a2eae372.png)

Working on other CSS issues with large header text.  